### PR TITLE
Preserve positional arguments that contain whitespace.

### DIFF
--- a/wp-su.sh
+++ b/wp-su.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 # This is a wrapper so that wp-cli can run as the www-data user so that permissions
 # remain correct
-sudo -u www-data /bin/wp-cli.phar $*
+sudo -u www-data /bin/wp-cli.phar "$@"


### PR DESCRIPTION
Prevents e.g.:

``` console
$ docker-compose run --rm wp-cli eval 'echo 12345;'
Error: Too many positional arguments: 12345;
```

See [SC2048](https://github.com/koalaman/shellcheck/wiki/SC2048).
