### PR TITLE
Add /bin/wp to chmod +x command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN apt-get update \
 # Add WP-CLI 
 RUN curl -o /bin/wp-cli.phar https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
 COPY wp-su.sh /bin/wp
-RUN chmod +x /bin/wp-cli.phar
+RUN chmod -x /bin/wp-cli.phar /bin/wp


### PR DESCRIPTION
Without this, the wp command is not found, and `docker exec` throws an error:

`oci runtime error: exec failed: container_linux.go:265: starting container process caused "exec: "wp": executable file not found in $PATH"`